### PR TITLE
Keep zeekygen close to their definitions

### DIFF
--- a/builtin-func.y
+++ b/builtin-func.y
@@ -327,8 +327,8 @@ definitions:	definitions definition opt_ws
 			}
 	|	opt_ws
 			{
-			fprintf(fp_zeek_init, "%s", $1);
 			fprintf(fp_zeek_init, "export {\n");
+			fprintf(fp_zeek_init, "%s", $1);
 			}
 	;
 


### PR DESCRIPTION
The Yacc grammar treats comments like other whitespace and when seeing the first definition in a file would previously emit all whitespace before emitting the `export` section containing the definition. This lead to the first definition being separated from their zeekygen documention (separated by `export {`).

With this patch we start the export section before emitting whitespace. While this might now pull more "whitespace" into the exported part, it avoids breaking the association between zeekygen comments and definitions.

Closes #15.