### PR TITLE
Use full path to filename in #line directives in generated code

### DIFF
--- a/builtin-func.y
+++ b/builtin-func.y
@@ -15,10 +15,11 @@ using namespace std;
 
 extern int line_number;
 extern char* input_filename;
+extern char* input_filename_with_path;
 extern char* plugin;
 extern int alternative_mode;
 
-#define print_line_directive(fp) fprintf(fp, "\n#line %d \"%s\"\n", line_number, input_filename)
+#define print_line_directive(fp) fprintf(fp, "\n#line %d \"%s\"\n", line_number, input_filename_with_path)
 
 extern FILE* fp_zeek_init;
 extern FILE* fp_func_def;


### PR DESCRIPTION
This fixes the DWARF information gets output by the compiler, and allows debuggers to use the full path name to display contextual information when a session stops inside of BIF code. With this patch, `lldb` now shows file context:

```
Process 6016 stopped
* thread #1, queue = 'com.apple.main-thread', stop reason = breakpoint 1.1
    frame #0: 0x00000001009dde58 zeek`zeek::BifFunc::Pcap::precompile_pcap_filter_bif(frame=0x000000011dea3e40, BiF_ARGS=0x000000016fdf9840 size=2) at pcap.bif:34:7
   31  	##          Pcap::error
   32  	function precompile_pcap_filter%(id: PcapFilterID, s: string%): bool
   33  		%{
-> 34  		if ( id->AsEnum() >= 100 )
   35  			{
   36  			// We use a vector as underlying data structure for fast
   37  			// lookups and limit the ID space so that that doesn't grow too
   ```