### PR TITLE
MSVC compiler warning fixes

### DIFF
--- a/builtin-func.l
+++ b/builtin-func.l
@@ -1,3 +1,11 @@
+%top{
+// Include stdint.h at the start of the generated file. Typically
+// MSVC will include this header later, after the definitions of
+// the integral type macros. MSVC then complains that about the
+// redefinition of the types. Including stdint.h early avoids this.
+#include <stdint.h>
+}
+
 %{
 #include <ctype.h>
 #include <string.h>

--- a/builtin-func.l
+++ b/builtin-func.l
@@ -314,9 +314,9 @@ void finish_alternative_mode()
 // FreeBSD doesn't support LeakSanitizer
 #if defined(USING_ASAN) && !defined(__FreeBSD__)
 	#include <sanitizer/lsan_interface.h>
-	#define BIFCL_LSAN_DISABLE(x) __lsan_disable(x)
+	#define BIFCL_LSAN_DISABLE() __lsan_disable()
 #else
-	#define BIFCL_LSAN_DISABLE(x)
+	#define BIFCL_LSAN_DISABLE()
 #endif
 
 int main(int argc, char* argv[])
@@ -396,7 +396,7 @@ int main(int argc, char* argv[])
 		fprintf(fp_netvar_init, "#pragma GCC diagnostic push\n");
 		fprintf(fp_netvar_init, "#pragma GCC diagnostic ignored \"-Wdeprecated-declarations\"\n\n");
 		fprintf(fp_netvar_init, "#endif\n");
-		
+
 		yy_switch_to_buffer(yy_create_buffer(fp_input, YY_BUF_SIZE));
 		yyparse();
 


### PR DESCRIPTION
This fixes the following warning from MSVC builds:

The first commit fixes this warning:
```
builtin-func.l(327): warning C4003: not enough arguments for function-like macro invocation 'BIFCL_LSAN_DISABLE'
```

The second commit fixes this block of warnings:
```
c:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Tools\MSVC\14.29.30133\include\stdint.h(49): warning C4005: 'INT8_MIN': macro redefinition
auxil\bifcl\bif_lex.cc(59): note: see previous definition of 'INT8_MIN'
c:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Tools\MSVC\14.29.30133\include\stdint.h(50): warning C4005: 'INT16_MIN': macro redefinition
auxil\bifcl\bif_lex.cc(62): note: see previous definition of 'INT16_MIN'
c:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Tools\MSVC\14.29.30133\include\stdint.h(51): warning C4005: 'INT32_MIN': macro redefinition
auxil\bifcl\bif_lex.cc(65): note: see previous definition of 'INT32_MIN'
c:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Tools\MSVC\14.29.30133\include\stdint.h(53): warning C4005: 'INT8_MAX': macro redefinition
auxil\bifcl\bif_lex.cc(68): note: see previous definition of 'INT8_MAX'
c:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Tools\MSVC\14.29.30133\include\stdint.h(54): warning C4005: 'INT16_MAX': macro redefinition
auxil\bifcl\bif_lex.cc(71): note: see previous definition of 'INT16_MAX'
c:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Tools\MSVC\14.29.30133\include\stdint.h(55): warning C4005: 'INT32_MAX': macro redefinition
auxil\bifcl\bif_lex.cc(74): note: see previous definition of 'INT32_MAX'
c:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Tools\MSVC\14.29.30133\include\stdint.h(57): warning C4005: 'UINT8_MAX': macro redefinition
auxil\bifcl\bif_lex.cc(77): note: see previous definition of 'UINT8_MAX'
c:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Tools\MSVC\14.29.30133\include\stdint.h(58): warning C4005: 'UINT16_MAX': macro redefinition
auxil\bifcl\bif_lex.cc(80): note: see previous definition of 'UINT16_MAX'
c:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Tools\MSVC\14.29.30133\include\stdint.h(59): warning C4005: 'UINT32_MAX': macro redefinition
auxil\bifcl\bif_lex.cc(83): note: see previous definition of 'UINT32_MAX'
```