### PR TITLE
Render runtime type checks for var_args bifs

### DIFF
--- a/builtin-func.y
+++ b/builtin-func.y
@@ -708,8 +708,8 @@ body_start:	TOK_LPB c_code_begin
 				fprintf(fp_func_def, "\tif ( %s->size() != %d )\n", arg_list_name, argc);
 				fprintf(fp_func_def, "\t\t{\n");
 				fprintf(fp_func_def,
-					"\t\treporter->Error(\"%s() takes exactly %d argument(s)\");\n",
-					decl.zeek_fullname.c_str(), argc);
+					"\t\tzeek::emit_builtin_error(zeek::util::fmt(\"%s() takes exactly %d argument(s), got %%lu\", %s->size()));\n",
+					decl.zeek_fullname.c_str(), argc, arg_list_name);
 				fprintf(fp_func_def, "\t\treturn nullptr;\n");
 				fprintf(fp_func_def, "\t\t}\n");
 				}
@@ -718,14 +718,14 @@ body_start:	TOK_LPB c_code_begin
 				fprintf(fp_func_def, "\tif ( %s->size() < %d )\n", arg_list_name, argc);
 				fprintf(fp_func_def, "\t\t{\n");
 				fprintf(fp_func_def,
-					"\t\treporter->Error(\"%s() takes at least %d argument(s)\");\n",
-					decl.zeek_fullname.c_str(), argc);
+					"\t\tzeek::emit_builtin_error(zeek::util::fmt(\"%s() takes at least %d argument(s), got %%lu\", %s->size()));\n",
+					decl.zeek_fullname.c_str(), argc, arg_list_name);
 				fprintf(fp_func_def, "\t\treturn nullptr;\n");
 				fprintf(fp_func_def, "\t\t}\n");
 				}
 
 			for ( int i = 0; i < (int) args.size(); ++i )
-				args[i]->PrintCDef(fp_func_def, i + implicit_arg);
+				args[i]->PrintCDef(fp_func_def, i + implicit_arg, var_arg);
 			print_line_directive(fp_func_def);
 			}
 	;

--- a/include/bif_arg.h
+++ b/include/bif_arg.h
@@ -25,7 +25,7 @@ public:
 	int Type() const { return type; }
 
 	void PrintZeek(FILE* fp);
-	void PrintCDef(FILE* fp, int n);
+	void PrintCDef(FILE* fp, int n, bool runtime_type_check = false);
 	void PrintCArg(FILE* fp, int n);
 	void PrintValConstructor(FILE* fp);
 


### PR DESCRIPTION
Currently, Zeek disables any static type checking for var_arg bifs. However, the generated preamble for var_args bifs assume that typed positional arguments are correctly typed and blindly calls the type converters on them. This easily triggers abort()s at runtime currently when a script mistakenly uses the wrong types for var_arg bifs. For example, calling publish_rr() with a port instead of a string causes a hard-abort with Zeek 5.0.8.

    $ zeek -e 'Cluster::publish_rr(Cluster::Pool(), 80/tcp)'
    fatal error in <no location>: Val::CONVERTER (port/string) (80/tcp)
    Aborted (core dumped)

Extend bifcl so that for var_arg functions and the types that bifcl understands, we render a runtime type check and explicit early return to avoid the abort(). For any/other types, the implementer of the bif continuous to be responsible for type checking.

This isn't solving the var_args situation generally, but avoids some ad-hoc fixes trickling in current bif implementations.

Some references:

https://github.com/zeek/zeek/issues/1523
https://github.com/zeek/zeek/issues/2425
https://github.com/zeek/zeek/issues/2935
https://github.com/zeek/zeek/pull/2950