### PR TITLE
Add #pragma once to generated headers

### DIFF
--- a/builtin-func.l
+++ b/builtin-func.l
@@ -215,6 +215,7 @@ void init_alternative_mode()
 	fprintf(fp_zeek_init, "# %s\n\n", auto_gen_comment);
 	fprintf(fp_func_def, "// %s\n\n", auto_gen_comment);
 	fprintf(fp_func_h, "// %s\n\n", auto_gen_comment);
+	fprintf(fp_func_h, "#pragma once\n\n");
 	fprintf(fp_func_init, "// %s\n\n", auto_gen_comment);
 
 	if ( fp_func_register )
@@ -387,9 +388,11 @@ int main(int argc, char* argv[])
 			fprintf(fp_zeek_init, "# %s\n\n", auto_gen_comment);
 			fprintf(fp_func_def, "// %s\n\n", auto_gen_comment);
 			fprintf(fp_func_h, "// %s\n\n", auto_gen_comment);
+			fprintf(fp_func_h, "#pragma once\n\n");
 			fprintf(fp_func_init, "// %s\n\n", auto_gen_comment);
 			fprintf(fp_netvar_def, "// %s\n\n", auto_gen_comment);
 			fprintf(fp_netvar_h, "// %s\n\n", auto_gen_comment);
+			fprintf(fp_netvar_h, "#pragma once\n\n");
 			fprintf(fp_netvar_init, "// %s\n\n", auto_gen_comment);
 			}
 


### PR DESCRIPTION
I've had this sitting on a branch for a while that I forgot about. This just adds `#pragma once` to the top of the headers generated by bifcl.