### PR TITLE
Switch namespacing in generated code to C++-17-style nested namespaces

### DIFF
--- a/.cmake-format.json
+++ b/.cmake-format.json
@@ -1,0 +1,101 @@
+{
+  "parse": {
+    "additional_commands": {
+      "CheckIPProto": {
+        "kwargs": {
+          "_proto": "*"
+        }
+      },
+      "CheckType": {
+        "kwargs": {
+          "_type": "*",
+          "_alt_type": "*",
+          "_var": "*"
+        }
+      },
+      "SetPackageVersion": {
+        "kwargs": {
+          "_version": "*"
+        }
+      },
+      "SetPackageFileName": {
+        "kwargs": {
+          "_version": "*"
+        }
+      },
+      "SetPackageInstallScripts": {
+        "kwargs": {
+          "VERSION": "*"
+        }
+      },
+      "ConfigurePackaging": {
+        "kwargs": {
+          "_version": "*"
+        }
+      },
+      "SetPackageGenerators": {},
+      "SetPackageMetadata": {},
+      "FindRequiredPackage": {
+        "kwargs": {
+          "packageName": "*"
+        }
+      },
+      "InstallClobberImmune": {
+        "kwargs": {
+          "_srcfile": "*",
+          "_dstfile": "*"
+        }
+      },
+      "InstallPackageConfigFile": {
+        "kwargs": {
+          "_srcfile": "*",
+          "_dstdir": "*",
+          "_dstfilename": "*"
+        }
+      },
+      "InstallShellScript": {
+        "kwargs": {
+          "_srcfile": "*",
+          "_dstfile": "*"
+        }
+      },
+      "InstallSymLink": {
+        "kwargs": {
+          "_filepath": "*",
+          "_sympath": "*"
+        }
+      },
+      "spicy_add_analyzer": {
+        "kwargs": {
+          "NAME": "*",
+          "PACKAGE_NAME": "*",
+          "SOURCES": "*",
+          "MODULES": "*"
+        }
+      },
+      "zeek_add_plugin": {
+        "kwargs": {
+          "INCLUDE_DIRS": "*",
+          "DEPENDENCIES": "*",
+          "SOURCES": "*",
+          "BIFS": "*",
+          "PAC": "*"
+        }
+      }
+    }
+  },
+  "format": {
+    "always_wrap": [
+      "spicy_add_analyzer",
+      "zeek_add_plugin"
+    ],
+    "line_width": 100,
+    "tab_size": 4,
+    "separate_ctrl_name_with_space": true,
+    "max_subgroups_hwrap": 3,
+    "line_ending": "unix"
+  },
+  "markup": {
+    "enable_markup": false
+  }
+}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@
 #
 repos:
 - repo: https://github.com/pre-commit/mirrors-clang-format
-  rev: 'v17.0.3'
+  rev: v19.1.7
   hooks:
   - id: clang-format
     types_or:
@@ -17,11 +17,6 @@ repos:
     - id: shfmt
       args: ["-w", "-i", "4", "-ci"]
 
-- repo: https://github.com/google/yapf
-  rev: v0.40.2
-  hooks:
-  - id: yapf
-
 - repo: https://github.com/cheshirekow/cmake-format-precommit
   rev: v0.6.13
   hooks:
@@ -29,7 +24,7 @@ repos:
     exclude: '^auxil/.*$'
 
 - repo: https://github.com/crate-ci/typos
-  rev: v1.16.21
+  rev: v1.30.1
   hooks:
     - id: typos
-      exclude: '^(.typos.toml|src/SmithWaterman.cc|testing/.*|auxil/.*|scripts/base/frameworks/files/magic/.*|CHANGES)$'
+      exclude: '^(.typos.toml|auxil/.*|CHANGES)$'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,28 +6,20 @@ include(cmake/CommonCMakeConfig.cmake)
 find_package(BISON REQUIRED)
 find_package(FLEX REQUIRED)
 
-if(MSVC)
-  add_compile_options(/J) # Similar to -funsigned-char on other platforms
-  set_property(
-    SOURCE bif_lex.cc
-    APPEND_STRING
-    PROPERTY COMPILE_FLAGS "/wd4018")
-else()
-  set_property(
-    SOURCE bif_lex.cc
-    APPEND_STRING
-    PROPERTY COMPILE_FLAGS "-Wno-sign-compare")
-endif()
+if (MSVC)
+    add_compile_options(/J) # Similar to -funsigned-char on other platforms
+    set_property(SOURCE bif_lex.cc APPEND_STRING PROPERTY COMPILE_FLAGS "/wd4018")
+else ()
+    set_property(SOURCE bif_lex.cc APPEND_STRING PROPERTY COMPILE_FLAGS "-Wno-sign-compare")
+endif ()
 
 include_directories(BEFORE ${BifCl_SOURCE_DIR}/include ${BifCl_BINARY_DIR})
 
 set(BISON_FLAGS "--debug")
 
 # BIF parser/scanner
-bison_target(
-  BIFParser builtin-func.y ${BifCl_BINARY_DIR}/bif_parse.cc
-  DEFINES_FILE ${BifCl_BINARY_DIR}/bif_parse.h
-  COMPILE_FLAGS "${BISON_FLAGS}")
+bison_target(BIFParser builtin-func.y ${BifCl_BINARY_DIR}/bif_parse.cc
+             DEFINES_FILE ${BifCl_BINARY_DIR}/bif_parse.h COMPILE_FLAGS "${BISON_FLAGS}")
 flex_target(BIFScanner builtin-func.l ${BifCl_BINARY_DIR}/bif_lex.cc)
 add_flex_bison_dependency(BIFScanner BIFParser)
 
@@ -45,35 +37,35 @@ add_executable(bifcl ${bifcl_SRCS})
 target_compile_features(bifcl PRIVATE cxx_std_17)
 set_target_properties(bifcl PROPERTIES CXX_EXTENSIONS OFF)
 
-if(MSVC)
-  # If building separately from zeek, we need to add the libunistd subdirectory
-  # so that linking doesn't fail.
-  if("${CMAKE_PROJECT_NAME}" STREQUAL "BifCl")
-    add_subdirectory(auxil/libunistd EXCLUDE_FROM_ALL)
-  endif()
-  target_link_libraries(bifcl PRIVATE libunistd)
-endif()
+if (MSVC)
+    # If building separately from zeek, we need to add the libunistd subdirectory
+    # so that linking doesn't fail.
+    if ("${CMAKE_PROJECT_NAME}" STREQUAL "BifCl")
+        add_subdirectory(auxil/libunistd EXCLUDE_FROM_ALL)
+    endif ()
+    target_link_libraries(bifcl PRIVATE libunistd)
+endif ()
 
 install(TARGETS bifcl DESTINATION bin)
 
-if(CMAKE_BUILD_TYPE)
-  string(TOUPPER ${CMAKE_BUILD_TYPE} BuildType)
-endif()
+if (CMAKE_BUILD_TYPE)
+    string(TOUPPER ${CMAKE_BUILD_TYPE} BuildType)
+endif ()
 
 message(
-  "\n====================|  Bifcl Build Summary  |====================="
-  "\n"
-  "\nBuild type:        ${CMAKE_BUILD_TYPE}"
-  "\nBuild dir:         ${PROJECT_BINARY_DIR}"
-  "\nInstall prefix:    ${CMAKE_INSTALL_PREFIX}"
-  "\nDebug mode:        ${ENABLE_DEBUG}"
-  "\n"
-  "\nCC:                ${CMAKE_C_COMPILER}"
-  "\nCFLAGS:            ${CMAKE_C_FLAGS} ${CMAKE_C_FLAGS_${BuildType}}"
-  "\nCXX:               ${CMAKE_CXX_COMPILER}"
-  "\nCXXFLAGS:          ${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_${BuildType}}"
-  "\nCPP:               ${CMAKE_CXX_COMPILER}"
-  "\n"
-  "\n================================================================\n")
+    "\n====================|  Bifcl Build Summary  |====================="
+    "\n"
+    "\nBuild type:        ${CMAKE_BUILD_TYPE}"
+    "\nBuild dir:         ${PROJECT_BINARY_DIR}"
+    "\nInstall prefix:    ${CMAKE_INSTALL_PREFIX}"
+    "\nDebug mode:        ${ENABLE_DEBUG}"
+    "\n"
+    "\nCC:                ${CMAKE_C_COMPILER}"
+    "\nCFLAGS:            ${CMAKE_C_FLAGS} ${CMAKE_C_FLAGS_${BuildType}}"
+    "\nCXX:               ${CMAKE_CXX_COMPILER}"
+    "\nCXXFLAGS:          ${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_${BuildType}}"
+    "\nCPP:               ${CMAKE_CXX_COMPILER}"
+    "\n"
+    "\n================================================================\n")
 
 include(UserChangedWarning)


### PR DESCRIPTION
This changes the bifcl generated code to use C++-17 nested namespaces so that instead of this:

```
namespace zeek { namespace BifType { namespace Enum{ namespace DCE_RPC {  extern zeek::IntrusivePtr<zeek::EnumType> PType;  } } }}
```

it now generates

```
namespace zeek::BifType::Enum::DCE_RPC { extern zeek::IntrusivePtr<zeek::EnumType> PType; }
```

It also does some house-keeping of pre-commit.