### PR TITLE
Add null check for pointer-based function arguments

### DIFF
--- a/bif_arg.cc
+++ b/bif_arg.cc
@@ -1,5 +1,4 @@
 
-#include <set>
 #include <string>
 using namespace std;
 

--- a/bif_arg.cc
+++ b/bif_arg.cc
@@ -1,10 +1,7 @@
-
-#include <string>
-using namespace std;
-
-#include <string.h>
-
 #include "bif_arg.h"
+
+#include <cstring>
+#include <string_view>
 
 static struct {
     const char* type_enum;


### PR DESCRIPTION
Fixes #33 

This adds a simple check for bif function arguments that map to pointer types. Unfortunately due to the generic-ness of the types defined in `include/bif_type.def`, the only real way to determine if it's a pointer is to check if the type string ends with `*`. 