### PR TITLE
Add one more instance of using nested namespaces

### DIFF
--- a/builtin-func.l
+++ b/builtin-func.l
@@ -277,17 +277,17 @@ void init_alternative_mode()
 		fprintf(fp_func_init, "#include \"zeek/Func.h\"\n");
 		fprintf(fp_func_init, "#include \"%s.h\"\n", input_filename);
 		fprintf(fp_func_init, "\n");
-		fprintf(fp_func_init, "namespace plugin { namespace %s {\n", plugin_canon);
+		fprintf(fp_func_init, "namespace plugin::%s {\n", plugin_canon);
 		fprintf(fp_func_init, "\n");
 		fprintf(fp_func_init, "void __bif_%s_init(zeek::plugin::Plugin* plugin)\n", name);
 		fprintf(fp_func_init, "\t{\n");
 
 		fprintf(fp_func_register, "#include \"zeek/plugin/Manager.h\"\n");
 		fprintf(fp_func_register, "\n");
-		fprintf(fp_func_register, "namespace plugin { namespace %s {\n", plugin_canon);
+		fprintf(fp_func_register, "namespace plugin::%s {\n", plugin_canon);
 		fprintf(fp_func_register, "void __bif_%s_init(zeek::plugin::Plugin* plugin);\n", name);
 		fprintf(fp_func_register, "zeek::plugin::detail::__RegisterBif __register_bifs_%s_%s(\"%s\", __bif_%s_init);\n", plugin_canon, name, plugin, name);
-		fprintf(fp_func_register, "} }\n");
+		fprintf(fp_func_register, "}\n");
         }
 	}
 
@@ -300,7 +300,7 @@ void finish_alternative_mode()
 		{
 		fprintf(fp_func_init, "\n");
 		fprintf(fp_func_init, "\t}\n");
-		fprintf(fp_func_init, "} }\n");
+		fprintf(fp_func_init, "}\n");
 		fprintf(fp_func_init, "\n");
 		fprintf(fp_func_init, "\n");
 		}

--- a/include/module_util.h
+++ b/include/module_util.h
@@ -6,14 +6,12 @@
 
 #include <string>
 
-using namespace std;
-
 static const char* GLOBAL_MODULE_NAME = "GLOBAL";
 
-extern string extract_module_name(const char* name);
-extern string extract_var_name(const char* name);
-extern string normalized_module_name(const char* module_name); // w/o ::
+extern std::string extract_module_name(const char* name);
+extern std::string extract_var_name(const char* name);
+extern std::string normalized_module_name(const char* module_name); // w/o ::
 
 // Concatenates module_name::var_name unless var_name is already fully
 // qualified, in which case it is returned unmodified.
-extern string make_full_var_name(const char* module_name, const char* var_name);
+extern std::string make_full_var_name(const char* module_name, const char* var_name);

--- a/module_util.cc
+++ b/module_util.cc
@@ -3,8 +3,10 @@
 
 #include "module_util.h"
 
-#include <string.h>
+#include <cstring>
 #include <string>
+
+using namespace std;
 
 static int streq(const char* s1, const char* s2) { return ! strcmp(s1, s2); }
 
@@ -36,7 +38,7 @@ string extract_var_name(const char* name) {
 
 string normalized_module_name(const char* module_name) {
     int mod_len;
-    if ( (mod_len = strlen(module_name)) >= 2 && streq(module_name + mod_len - 2, "::") )
+    if ( mod_len = strlen(module_name); mod_len >= 2 && streq(module_name + mod_len - 2, "::") )
         mod_len -= 2;
 
     return string(module_name, mod_len);


### PR DESCRIPTION
I missed this one in https://github.com/zeek/bifcl/pull/36.

This also removes a use of `using namespace std` from a header, where we shouldn't be doing that, and adds a little code modernization. 