### PR TITLE
Fixes from clang-tidy work

### DIFF
--- a/bif_arg.cc
+++ b/bif_arg.cc
@@ -1,11 +1,6 @@
-
-#include <set>
-#include <string>
-using namespace std;
-
-#include <string.h>
-
 #include "bif_arg.h"
+
+#include <cstring>
 
 static struct {
     const char* type_enum;

--- a/builtin-func.l
+++ b/builtin-func.l
@@ -1,15 +1,15 @@
 %top{
-// Include stdint.h at the start of the generated file. Typically
+// Include cstdint at the start of the generated file. Typically
 // MSVC will include this header later, after the definitions of
 // the integral type macros. MSVC then complains that about the
-// redefinition of the types. Including stdint.h early avoids this.
-#include <stdint.h>
+// redefinition of the types. Including cstdint early avoids this.
+#include <cstdint>
 }
 
 %{
 #include <ctype.h>
-#include <string.h>
 #include <unistd.h>
+#include <cstring>
 #include <memory>
 #include "bif_arg.h"
 #include "bif_parse.h"

--- a/builtin-func.y
+++ b/builtin-func.y
@@ -584,7 +584,7 @@ head_1:		TOK_ID opt_ws arg_begin
 			if ( definition_type == FUNC_DEF )
 				{
 				fprintf(fp_func_init,
-					"\t(void) new zeek::detail::BuiltinFunc(zeek::%s_bif, \"%s\", 0);\n",
+					"\t(void) new zeek::detail::BuiltinFunc(zeek::%s_bif, \"%s\", false);\n",
 					decl.c_fullname.c_str(), decl.zeek_fullname.c_str());
 
 				// This is the "canonical" version, with argument type and order

--- a/builtin-func.y
+++ b/builtin-func.y
@@ -37,7 +37,7 @@ string type_name;
 // already been defined/written to the C++ files.
 static std::set<std::string> events;
 
-enum {
+enum : uint8_t {
 	C_SEGMENT_DEF,
 	FUNC_DEF,
 	EVENT_DEF,

--- a/builtin-func.y
+++ b/builtin-func.y
@@ -1,11 +1,10 @@
 %{
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
 #include <vector>
 #include <set>
 #include <string>
-#include <cstring>
-
-#include <stdio.h>
-#include <stdlib.h>
 
 #include "module_util.h"
 

--- a/include/bif_arg.h
+++ b/include/bif_arg.h
@@ -3,7 +3,7 @@
 #include <cstdint>
 #include <cstdio>
 
-enum builtin_func_arg_type {
+enum builtin_func_arg_type : uint8_t {
 #define DEFINE_BIF_TYPE(id, bif_type, bro_type, c_type, c_type_smart, accessor, accessor_smart, cast_smart,            \
                         constructor, ctor_smart)                                                                       \
     id,

--- a/include/bif_arg.h
+++ b/include/bif_arg.h
@@ -1,6 +1,7 @@
 #pragma once
 
-#include <stdio.h>
+#include <cstdint>
+#include <cstdio>
 
 enum builtin_func_arg_type {
 #define DEFINE_BIF_TYPE(id, bif_type, bro_type, c_type, c_type_smart, accessor, accessor_smart, cast_smart,            \

--- a/include/module_util.h
+++ b/include/module_util.h
@@ -6,7 +6,7 @@
 
 #include <string>
 
-static const char* GLOBAL_MODULE_NAME = "GLOBAL";
+static constexpr const char* GLOBAL_MODULE_NAME = "GLOBAL";
 
 extern std::string extract_module_name(const char* name);
 extern std::string extract_var_name(const char* name);

--- a/module_util.cc
+++ b/module_util.cc
@@ -16,7 +16,7 @@ string extract_module_name(const char* name) {
     string::size_type pos = module_name.rfind("::");
 
     if ( pos == string::npos )
-        return string(GLOBAL_MODULE_NAME);
+        return GLOBAL_MODULE_NAME;
 
     module_name.erase(pos);
 
@@ -31,17 +31,17 @@ string extract_var_name(const char* name) {
         return var_name;
 
     if ( pos + 2 > var_name.size() )
-        return string("");
+        return "";
 
     return var_name.substr(pos + 2);
 }
 
 string normalized_module_name(const char* module_name) {
-    int mod_len;
+    size_t mod_len;
     if ( mod_len = strlen(module_name); mod_len >= 2 && streq(module_name + mod_len - 2, "::") )
         mod_len -= 2;
 
-    return string(module_name, mod_len);
+    return {module_name, mod_len};
 }
 
 string make_full_var_name(const char* module_name, const char* var_name) {
@@ -49,7 +49,7 @@ string make_full_var_name(const char* module_name, const char* var_name) {
         if ( streq(GLOBAL_MODULE_NAME, extract_module_name(var_name).c_str()) )
             return extract_var_name(var_name);
 
-        return string(var_name);
+        return var_name;
     }
 
     string full_name = normalized_module_name(module_name);


### PR DESCRIPTION
This is related to some clang-tidy work I'm doing in the Zeek repo. The first commit here is fixing a finding from clang-tidy in the generated output from bifcl. The rest are just some cleanups in the bifcl code itself that I found along the way.